### PR TITLE
Remove shameful whitelist from Schacks list

### DIFF
--- a/assets/thirdparties/adblock.schack.dk/block.txt
+++ b/assets/thirdparties/adblock.schack.dk/block.txt
@@ -853,6 +853,3 @@ bornholmermarked.dk/nonsec/NPIX/Banner/
 ||specificclick.net
 ||adnxs.com
 #||b.scorecardresearch.com
-
-! whitelist Google adds
-@@googleads.g.doubleclick.net


### PR DESCRIPTION
Henrik Schack have whitelisted Google's ads in his list.
This whitelist makes the annoying video ads on YouTube appear.

His list is about ads and annoyances on Danish sites, so it doesn't make sense that it contains rules for Google. I seriously wonder whether he have been paid to add the whitelist..
