### PR TITLE
Safari: remove extra call to popup resize -- now smoother

### DIFF
--- a/platform/safari/vapi-popup.js
+++ b/platform/safari/vapi-popup.js
@@ -35,10 +35,9 @@ var whenSizeChanges = function(elm, callback) {
 var onLoaded = function() {
     var body = document.body, popover = safari.self;
     var updateSize = function() {
-        popover.width = body.offsetWidth;
-        popover.height = body.offsetHeight;
+        popover.width = body.clientWidth;
+        popover.height = body.clientHeight;
     };
-    updateSize();
     body.style.position = "relative"; // Necessary for size change detection
     whenSizeChanges(body, updateSize);
 };


### PR DESCRIPTION
Pretty much perfect popup-open animation on Safari now. :)
