### PR TITLE
Way simplify vAPI closePopup for Safari

### DIFF
--- a/platform/safari/vapi-common.js
+++ b/platform/safari/vapi-common.js
@@ -114,22 +114,10 @@ vAPI.i18n = function(s) {
 /******************************************************************************/
 
 vAPI.closePopup = function() {
-    var safr = safari.extension.globalPage.contentWindow.safari;
-    var items = safr.extension.toolbarItems;
-
-    for ( var i = 0; i < items.length; i++ ) {
-        if ( items[i].browserWindow !== safr.application.activeBrowserWindow ) {
-            continue;
-        }
-
-        if ( items[i].popover && items[i].popover.visible ) {
-            items[i].popover.hide();
-        }
+    var popover = safari.extension.popovers[0];
+    if ( popover ) {
+        popover.hide();
     }
 };
 
-/******************************************************************************/
-
 })();
-
-/******************************************************************************/


### PR DESCRIPTION
From [Apple's documentation](https://developer.apple.com/library/safari/documentation/Tools/Conceptual/SafariExtensionGuide/AddingPopovers/AddingPopovers.html):

> Your extension can have multiple popovers. Each popover is an element in the `safari.extension.popovers` array. There is a single instance of each popover, regardless of the number of open windows. Only the active window can display the popover.

Use that to hugely simplify `vAPI.closePopup`.
