### PR TITLE
Better uBlock title/logo arrangement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ![logo](https://raw.githubusercontent.com/gorhill/uBlock/master/src/img/icon_128.png) µBlock
+# ![logo](https://raw.githubusercontent.com/gorhill/uBlock/master/src/img/icon_128.png)
 
-**An efficient blocker for WebKit- and Blink-based browsers. Fast, potent, and lean.**
+**µBlock**: an efficient blocker for WebKit- and Blink-based browsers. Fast, potent, and lean.
 
 * [Purpose & General Info](#philosophy)
 * [Performance and Efficiency](#performance)


### PR DESCRIPTION
Most recent commit (from PR #493) addressed a well-taken problem (too much space was wasted), but logo/text are now vertically misaligned and visually unpleasing. This alternate arrangement gives back the space while keeping the README visually non-intimidating and gentle:

![new README look](http://chrisly.me/image/1N0i3s3S1z0s/Image%202015-01-13%20at%204.09.47%20PM.png)
