### PR TITLE
Change Safari build

### DIFF
--- a/tools/make-safari.sh
+++ b/tools/make-safari.sh
@@ -26,10 +26,7 @@ echo "*** uBlock.safariextension: Generating meta..."
 python tools/make-safari-meta.py $DES/
 
 if [ "$1" = all ]; then
-    echo "*** uBlock.safariextension: Creating package..."
-    pushd $DES/
-    zip ../uBlock.safari.safariextension -qr *
-    popd
+    echo "*** Use Safari's Extension Builder to create the signed uBlock extension package -- can't automate it."
 fi
 
 echo "*** uBlock.safariextension: Package done."


### PR DESCRIPTION
You can't build a Safari extension package from the command line without a hack (have to have a certificate to sign, must use Extension Builder). make-safari all generated a weird zip file that doesn't work in any way, shape, or form. Print helpful message instead.
