### PR TITLE
Remove Chromium-specific language from description

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description":"extension name."
   },
   "extShortDesc":{
-    "message":"Finally, an efficient blocker for Chromium-based browsers. Easy on CPU and memory.",
+    "message":"Finally, an efficient blocker. Easy on CPU and memory.",
     "description":"this will be in the chrome web store: must be 132 characters or less"
   },
   "dashboardName":{


### PR DESCRIPTION
This looks funny when running in Firefox.
