### PR TITLE
Safari version publicly available + add developer identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
   * [CPU](#cpu)
   * [Blocking](#blocking)
 * [Installation](#installation)
+  * [Chrome](#chrome)
+  * [Safari](#safari)
+  * [Firefox](#firefox)
+  * [Opera](#opera)
+  * [Manually](#manually)
 * [Release History](#release-history)
 * [Wiki](https://github.com/gorhill/uBlock/wiki)
 
@@ -56,11 +61,31 @@ Being lean and efficient doesn't mean blocking less<br>
 
 ## Installation
 
-Install µBlock from the [Chrome store](https://chrome.google.com/webstore/detail/cjpalhdlnbpafiamejdnhcphjbkeiagm), the [Opera store](https://addons.opera.com/en-gb/extensions/details/ublock/), or [manually](https://github.com/gorhill/uBlock/tree/master/dist#install).
-
 Feel free to read [about the extension's required permissions](https://github.com/gorhill/uBlock/wiki/About-the-required-permissions).
 
-**Note:**
+### Chrome
+
+[![Chrome Web Store](https://developer.chrome.com/webstore/images/ChromeWebStore_Badge_v2_340x96.png)](https://chrome.google.com/webstore/detail/cjpalhdlnbpafiamejdnhcphjbkeiagm).
+
+µBlock is available for free from the [Chrome Web Store](https://chrome.google.com/webstore/detail/cjpalhdlnbpafiamejdnhcphjbkeiagm).
+
+### Safari
+
+µBlock will hopefully soon be published on Apple's Safari Extension Gallery. Meanwhile, feel free to grab the [latest version here](https://chrismatic.io/ublock) from µBlock's Safari maintainer.
+
+### Firefox
+
+Coming soon.
+
+### Opera
+
+µBlock is available from the [Opera store](https://addons.opera.com/en-gb/extensions/details/ublock/).
+
+### Manually
+
+If you wish to install µBlock manually, [check out this guide](https://github.com/gorhill/uBlock/tree/master/dist#install).
+
+### Note for all browsers
 
 To benefit from µBlock's higher efficiency, it's advised that you don't use other inefficient blockers at the same time (such as AdBlock or Adblock Plus). µBlock will do [as well or better](#blocking) than most popular ad blockers.
 

--- a/platform/safari/Update.plist
+++ b/platform/safari/Update.plist
@@ -8,13 +8,13 @@
 				<key>CFBundleIdentifier</key>
 				<string>net.gorhill.uBlock</string>
 				<key>Developer Identifier</key>
-				<string>...</string>
+				<string>96G4BAKDQ9</string>
 				<key>CFBundleShortVersionString</key>
 				<string>{version}</string>
 				<key>CFBundleVersion</key>
 				<string>{buildNumber}</string>
 				<key>URL</key>
-				<string>https://github.com/gorhill/uBlock/releases/download/0.7.0.11/uBlock-0.7.0.11.safariextz</string>
+				<string>https://chrismatic.io/ublock/ublock-0.8.5.4.safariextz</string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
- Safari version installation instructions.
- Restructure installation section of README to be tidier ([see resulting README](https://github.com/chrisaljoudi/uBlock)).
