### PR TITLE
Fix `set` for Firefox & Safari (skip non-own properties in for..in loop)

### DIFF
--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -195,6 +195,9 @@ vAPI.storage = {
         var key, values = [], placeholders = [];
 
         for ( key in details ) {
+            if ( !details.hasOwnProperty(key) ) {
+                continue;
+            }
             values.push(key);
             values.push(JSON.stringify(details[key]));
             placeholders.push('?, ?');

--- a/platform/safari/vapi-background.js
+++ b/platform/safari/vapi-background.js
@@ -126,6 +126,9 @@ vAPI.storage = {
 
     set: function(details, callback) {
         for ( var key in details ) {
+            if ( !details.hasOwnProperty(key) ) {
+                continue;
+            }
             this._storage.setItem(key, JSON.stringify(details[key]));
         }
 


### PR DESCRIPTION
Should fix #523 
