### PR TITLE
Big improvements to Safari event capturing + tweak info.plist

### DIFF
--- a/platform/safari/Info.plist
+++ b/platform/safari/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Author</key>
-    <string>{author}</string>
+    <string>Chris Aljoudi (core by gorhill)</string>
     <key>Builder Version</key>
     <string>534.57.2</string>
     <key>CFBundleDisplayName</key>
@@ -83,8 +83,8 @@
             <string>All</string>
         </dict>
     </dict>
-    <!-- <key>Update Manifest URL</key>
-    <string>https://raw.githubusercontent.com/gorhill/uBlock/master/dist/Update.plist</string> -->
+    <key>Update Manifest URL</key>
+    <string>https://chrismatic.io/ublock/Update.plist</string>
     <key>Website</key>
     <string>https://github.com/gorhill/uBlock</string>
 </dict>

--- a/platform/safari/vapi-background.js
+++ b/platform/safari/vapi-background.js
@@ -190,21 +190,32 @@ vAPI.tabs = {
 vAPI.tabs.registerListeners = function() {
     var onNavigation = this.onNavigation;
 
-    this.onNavigation = function(e) {
-        // e.url is not present for local files or data URIs,
-        // or probably for those URLs which we don't have access to
-        if ( !e.target || !e.target.url ) {
+    safari.application.addEventListener('beforeNavigate', function(e) {
+        if ( !e.target || !e.target.url || e.target.url === 'about:blank' ) {
             return;
         }
-
+        var url = e.target.url, tabId = vAPI.tabs.getTabId(e.target);
+        if ( vAPI.tabs.popupCandidate ) {
+            var details = {
+                url: url,
+                tabId: tabId,
+                sourceTabId: vAPI.tabs.popupCandidate
+            };
+            vAPI.tabs.popupCandidate = false;
+            if ( vAPI.tabs.onPopup(details) ) {
+                e.preventDefault();
+                if ( vAPI.tabs.stack[details.sourceTabId] ) {
+                    vAPI.tabs.stack[details.sourceTabId].activate();
+                }
+                return;
+            }
+        }
         onNavigation({
+            url: url,
             frameId: 0,
-            tabId: vAPI.tabs.getTabId(e.target),
-            url: e.target.url
+            tabId: tabId
         });
-    };
-
-    safari.application.addEventListener('navigate', this.onNavigation, true);
+    }, true);
 
     // onClosed handled in the main tab-close event
     // onUpdated handled via monitoring the history.pushState on web-pages
@@ -577,27 +588,6 @@ vAPI.messaging.broadcast = function(message) {
 
 /******************************************************************************/
 
-safari.application.addEventListener('beforeNavigate', function(e) {
-    if ( !vAPI.tabs.popupCandidate || e.url === 'about:blank' ) {
-        return;
-    }
-
-    var details = {
-        url: e.url,
-        tabId: vAPI.tabs.getTabId(e.target),
-        sourceTabId: vAPI.tabs.popupCandidate
-    };
-
-    vAPI.tabs.popupCandidate = null;
-
-    if ( vAPI.tabs.onPopup(details) ) {
-        e.preventDefault();
-
-        if ( vAPI.tabs.stack[details.sourceTabId] ) {
-            vAPI.tabs.stack[details.sourceTabId].activate();
-        }
-    }
-}, true);
 
 /******************************************************************************/
 

--- a/platform/safari/vapi-client.js
+++ b/platform/safari/vapi-client.js
@@ -200,7 +200,7 @@ var frameId = window === window.top ? 0 : Date.now() % 1E5;
 var parentFrameId = frameId ? 0 : -1;
 var linkHelper = document.createElement('a');
 var onBeforeLoad = function(e, details) {
-    if ( e.url && e.url.lastIndexOf('data:', 0) == 0 ) {
+    if ( e.url && e.url.lastIndexOf('data:', 0) === 0 ) {
         return;
     }
 


### PR DESCRIPTION
There were some significant issues with the way navigation events were being handled (extraneous listeners, etc.). This includes a cleanup of that — increased overall efficiency is expected, and this also fixes #541.

Because this touches some core components of the Safari extension, I'll be doing even more testing for a bit before I push the next automatic update.
