### PR TITLE
Removed stats.pusher.com from easyprivacy.txt

### DIFF
--- a/assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
+++ b/assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
@@ -7990,7 +7990,6 @@ http://utm.
 ||stats.paypal.com^
 ||stats.piaggio.com^
 ||stats.propublica.org^
-||stats.pusher.com^
 ||stats.radiostreamlive.com^
 ||stats.searchftps.org^
 ||stats.searchsight.com^


### PR DESCRIPTION
Hi there,

I work for a company called Pusher - ( http://pusher.com ) - and we're an API that lets developers add realtime functionality to their applications.

I was wondering if it would be possible to remove stats.pusher.com from the whitelist.

Our Javascript library makes calls to this URL to let customers view statistics about their usage. A few customers have been complaining about statistics being out of sync due to blockers. 

Just to allay any concerns, we do not send any private data to this endpoint, and we do not store or show app messages. It is merely that we and the developers who use us can have an accurate dashboard.

Thanks,

Jamie
