### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 * [Wiki](https://github.com/gorhill/uBlock/wiki)
 
 ![Build](https://travis-ci.org/gorhill/uBlock.svg?branch=master)
+[![Inline docs](http://inch-ci.org/github/gorhill/uBlock.svg?branch=master)](http://inch-ci.org/github/gorhill/uBlock)
 
 ## Philosophy
 


### PR DESCRIPTION
Hi Raymond,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/gorhill/uBlock.svg)](http://inch-ci.org/github/gorhill/uBlock)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs. Besides testing and other coverage, documenting your code is often neglected although it is a very engaging part of Open Source.

So far over 500 **Ruby** projects are sporting these badges to raise awareness for the importance of inline-docs and to show potential contributors that they can expect a certain level of code documentation when they dive into your project's code and motivate them to eventually document their own. 

I would really like to do the same for the **JavaScript** community and roll out support for JS over the coming weeks (early adopters are [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [Shipit](https://github.com/shipitjs/shipit)).

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/gorhill/uBlock

What do you think?
