### PR TITLE
Link the build badge to Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 * [Release History](#release-history)
 * [Wiki](https://github.com/gorhill/uBlock/wiki)
 
-# ![Build](https://travis-ci.org/gorhill/uBlock.svg?branch=master)
+# [![Build Status](https://travis-ci.org/gorhill/uBlock.svg?branch=master)](https://travis-ci.org/gorhill/uBlock)
 
 ## Philosophy
 


### PR DESCRIPTION
Now when the badge is clicked, it just links to the image file. This makes the badge to link to the appropriate Travis CI website.
