### PR TITLE
Fix for #1072: Listen to DOMTitleChanged

### DIFF
--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -296,7 +296,6 @@ var windowWatcher = {
             // Fennec
             tabContainer = tabBrowser.deck;
             tabContainer.addEventListener('DOMTitleChanged', tabWatcher.onFennecLocationChange);
-
         } else if ( tabBrowser.tabContainer ) {
             // desktop Firefox
             tabContainer = tabBrowser.tabContainer;
@@ -471,6 +470,7 @@ vAPI.tabs.registerListeners = function() {
             if ( tabBrowser.deck ) {
                 // Fennec
                 tabContainer = tabBrowser.deck;
+                tabContainer.removeEventListener('DOMTitleChanged', tabWatcher.onFennecLocationChange);
             } else if ( tabBrowser.tabContainer ) {
                 tabContainer = tabBrowser.tabContainer;
                 tabBrowser.removeTabsProgressListener(tabWatcher);

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -295,6 +295,8 @@ var windowWatcher = {
         if ( tabBrowser.deck ) {
             // Fennec
             tabContainer = tabBrowser.deck;
+            tabContainer.addEventListener('DOMTitleChanged', tabWatcher.onFennecLocationChange);
+
         } else if ( tabBrowser.tabContainer ) {
             // desktop Firefox
             tabContainer = tabBrowser.tabContainer;
@@ -375,6 +377,23 @@ var tabWatcher = {
             url: location.asciiSpec
         });
     },
+
+    onFennecLocationChange: function({target: doc}) {
+        // Fennec "equivalent" to onLocationChange
+        // note that DOMTitleChanged is selected as it fires very early
+        // (before DOMContentLoaded), and it does fire even if there is no title
+        var win = doc.defaultView;
+        if ( win !== win.top ) {
+            return;
+        }
+
+        vAPI.tabs.onNavigation({
+            frameId: 0,
+            tabId: vAPI.tabs.getTabId(getOwnerWindow(win).BrowserApp.getTabForWindow(win)),
+            url: Services.io.newURI(win.location.href, null, null).asciiSpec
+        });
+    }
+
 };
 
 /******************************************************************************/


### PR DESCRIPTION
When a page is loaded without any http request being made the onLocationChange from httpObserver is never triggered. Adding back in the DOMTitleChanged event handler will ensure onLocationChange is also called in those circumstances.

On the down side, it means that most pages will have onLocationChange called twice. This _appears_ to be harmless, but if you know it to be an issue then further work would be required.
