### PR TITLE
Update easyprivacy.txt

### DIFF
--- a/assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
+++ b/assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
@@ -8320,7 +8320,6 @@ http://utm.
 ||truthdig.com/?ACT=
 ||tscapeplay.com/msvp.php?
 ||tscapeplay.com/pvim?
-||tsn.ua/svc/video/stat/
 ||ttxm.co.uk^*/log.js
 ||tubeplus.me/geoip.php?
 ||tubeplus.me/imp.php?


### PR DESCRIPTION
Some videos on tsn.ua do not work while activating easyprivacy list on my AdBlock and vice versa. I assume that the culprit is this line, but please double-check. This link is random example of that bug: http://tsn.ua/video/video-novini/planetoyu-krokuye-godina-zemli.html
