### PR TITLE
Use webProgressListener instead of tabsProgressListener

### DIFF
--- a/platform/firefox/frameModule.js
+++ b/platform/firefox/frameModule.js
@@ -323,7 +323,7 @@ const LocationChangeListener = function(docShell) {
             this.docShell.addProgressListener(this, Ci.nsIWebProgress.NOTIFY_LOCATION);
         }
     }
-}
+};
 
 LocationChangeListener.prototype.QueryInterface = XPCOMUtils.generateQI(["nsIWebProgressListener", "nsISupportsWeakReference"]);
 

--- a/platform/firefox/frameModule.js
+++ b/platform/firefox/frameModule.js
@@ -317,7 +317,7 @@ const LocationChangeListener = function(docShell) {
         this.messageManager = docShell.getInterface(Ci.nsIContentFrameMessageManager);
 
         if (this.messageManager && typeof this.messageManager.sendAsyncMessage === 'function') {
-            this.docShell.addProgressListener(this, Ci.nsIWebProgress.NOTIFY_ALL);
+            this.docShell.addProgressListener(this, Ci.nsIWebProgress.NOTIFY_LOCATION);
         }
     }
 }

--- a/platform/firefox/frameScript.js
+++ b/platform/firefox/frameScript.js
@@ -21,13 +21,15 @@
 
 /******************************************************************************/
 
+var locationChangeListener; // Keep alive while frameScript is alive
+
 (function() {
 
 'use strict';
 
 /******************************************************************************/
 
-let {contentObserver} = Components.utils.import(
+let {contentObserver, LocationChangeListener} = Components.utils.import(
     Components.stack.filename.replace('Script', 'Module'),
     null
 );
@@ -53,6 +55,8 @@ let onLoadCompleted = function() {
 };
 
 addMessageListener('ublock-load-completed', onLoadCompleted);
+
+locationChangeListener = new LocationChangeListener(docShell);
 
 /******************************************************************************/
 

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -342,7 +342,8 @@ var tabWatcher = {
             return;
         }
 
-        if ( browser.webNavigation.busyFlags === 0  /*BUSY_FLAGS_NONE*/ ) {
+        if ( browser.webNavigation.busyFlags === 0 || /*BUSY_FLAGS_NONE*/ 
+             browser.webNavigation.busyFlags === undefined) {
             vAPI.tabs.onNavigation({
                 frameId: 0,
                 tabId: tabId,

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -327,24 +327,8 @@ var tabWatcher = {
     },
 
     onTabSelect: function({target}) {
-        // target is tab in Firefox, browser in Fennec
-        var browser = (target.linkedBrowser || target);
-        var URI = browser.currentURI;
-        var aboutPath = URI.schemeIs('about') && URI.path;
-        var tabId = vAPI.tabs.getTabId(target);
-
-        if ( !aboutPath || (aboutPath !== 'blank' && aboutPath !== 'newtab') ) {
-            vAPI.setIcon(tabId, getOwnerWindow(target));
-            return;
-        }
-
-        if ( browser.webNavigation.busyFlags === 0  /*BUSY_FLAGS_NONE*/ ) {
-            vAPI.tabs.onNavigation({
-                frameId: 0,
-                tabId: tabId,
-                url: URI.asciiSpec
-            });
-        }
+        vAPI.setIcon(vAPI.tabs.getTabId(target), getOwnerWindow(target));
+        return;
     },
 };
 

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -298,7 +298,6 @@ var windowWatcher = {
         } else if ( tabBrowser.tabContainer ) {
             // desktop Firefox
             tabContainer = tabBrowser.tabContainer;
-            tabBrowser.addTabsProgressListener(tabWatcher);
             vAPI.contextMenu.register(this.document);
         } else {
             return;
@@ -320,8 +319,6 @@ var windowWatcher = {
 /******************************************************************************/
 
 var tabWatcher = {
-    SAME_DOCUMENT: Ci.nsIWebProgressListener.LOCATION_CHANGE_SAME_DOCUMENT,
-
     onTabClose: function({target}) {
         // target is tab in Firefox, browser in Fennec
         var tabId = vAPI.tabs.getTabId(target);
@@ -348,32 +345,6 @@ var tabWatcher = {
                 url: URI.asciiSpec
             });
         }
-    },
-
-    onLocationChange: function(browser, webProgress, request, location, flags) {
-        if ( !webProgress.isTopLevel ) {
-            return;
-        }
-
-        var tabId = vAPI.tabs.getTabId(browser);
-
-        // LOCATION_CHANGE_SAME_DOCUMENT = "did not load a new document"
-        if ( flags & this.SAME_DOCUMENT ) {
-            vAPI.tabs.onUpdated(tabId, {url: location.asciiSpec}, {
-                frameId: 0,
-                tabId: tabId,
-                url: browser.currentURI.asciiSpec
-            });
-            return;
-        }
-
-        // https://github.com/gorhill/uBlock/issues/105
-        // Allow any kind of pages
-        vAPI.tabs.onNavigation({
-            frameId: 0,
-            tabId: tabId,
-            url: location.asciiSpec
-        });
     },
 };
 
@@ -426,7 +397,6 @@ vAPI.tabs = {};
 /******************************************************************************/
 
 vAPI.tabs.registerListeners = function() {
-    // onNavigation and onUpdated handled with tabWatcher.onLocationChange
     // onClosed - handled in tabWatcher.onTabClose
     // onPopup - handled in httpObserver.handlePopup
 
@@ -1232,14 +1202,6 @@ var httpObserver = {
             return;
         }
 
-        if ( vAPI.fennec && lastRequest.type === this.MAIN_FRAME ) {
-            vAPI.tabs.onNavigation({
-                frameId: 0,
-                tabId: lastRequest.tabId,
-                url: URI.asciiSpec
-            });
-        }
-
         // If request is not handled we may use the data in on-modify-request
         if ( channel instanceof Ci.nsIWritablePropertyBag ) {
             channel.setProperty(this.REQDATAKEY, [
@@ -1361,12 +1323,49 @@ vAPI.net.registerListeners = function() {
         shouldLoadListener
     );
 
+    var locationChangedListenerMessageName = location.host + ':locationChanged';
+    var locationChangedListener = function(e) {
+        var details = e.data;
+        var browser = e.target;
+        var tabId = vAPI.tabs.getTabId(browser);
+        
+        //console.debug("nsIWebProgressListener: onLocationChange: " + details.url + " (" + details.flags + ")");        
+
+        // LOCATION_CHANGE_SAME_DOCUMENT = "did not load a new document"
+        if ( details.flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_SAME_DOCUMENT ) {
+            vAPI.tabs.onUpdated(tabId, {url: details.url}, {
+                frameId: 0,
+                tabId: tabId,
+                url: browser.currentURI.asciiSpec
+            });
+            return;
+        }
+
+        // https://github.com/gorhill/uBlock/issues/105
+        // Allow any kind of pages
+        vAPI.tabs.onNavigation({
+            frameId: 0,
+            tabId: tabId,
+            url: details.url,
+        });
+    }
+
+    vAPI.messaging.globalMessageManager.addMessageListener(
+        locationChangedListenerMessageName,
+        locationChangedListener
+    );
+
     httpObserver.register();
 
     cleanupTasks.push(function() {
         vAPI.messaging.globalMessageManager.removeMessageListener(
             shouldLoadListenerMessageName,
             shouldLoadListener
+        );
+
+        vAPI.messaging.globalMessageManager.removeMessageListener(
+            locationChangedListenerMessageName,
+            locationChangedListener
         );
 
         httpObserver.unregister();

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -328,7 +328,6 @@ var tabWatcher = {
 
     onTabSelect: function({target}) {
         vAPI.setIcon(vAPI.tabs.getTabId(target), getOwnerWindow(target));
-        return;
     },
 };
 
@@ -408,7 +407,6 @@ vAPI.tabs.registerListeners = function() {
                 tabContainer = tabBrowser.deck;
             } else if ( tabBrowser.tabContainer ) {
                 tabContainer = tabBrowser.tabContainer;
-                tabBrowser.removeTabsProgressListener(tabWatcher);
             }
 
             tabContainer.removeEventListener('TabClose', tabWatcher.onTabClose);
@@ -1348,7 +1346,7 @@ vAPI.net.registerListeners = function() {
             tabId: tabId,
             url: details.url,
         });
-    }
+    };
 
     vAPI.messaging.globalMessageManager.addMessageListener(
         locationChangedListenerMessageName,

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -331,25 +331,8 @@ var tabWatcher = {
     },
 
     onTabSelect: function({target}) {
-        // target is tab in Firefox, browser in Fennec
-        var browser = (target.linkedBrowser || target);
-        var URI = browser.currentURI;
-        var aboutPath = URI.schemeIs('about') && URI.path;
-        var tabId = vAPI.tabs.getTabId(target);
-
-        if ( !aboutPath || (aboutPath !== 'blank' && aboutPath !== 'newtab') ) {
-            vAPI.setIcon(tabId, getOwnerWindow(target));
-            return;
-        }
-
-        if ( browser.webNavigation.busyFlags === 0 || /*BUSY_FLAGS_NONE*/ 
-             browser.webNavigation.busyFlags === undefined) {
-            vAPI.tabs.onNavigation({
-                frameId: 0,
-                tabId: tabId,
-                url: URI.asciiSpec
-            });
-        }
+        vAPI.setIcon(vAPI.tabs.getTabId(target), getOwnerWindow(target));
+        return;
     },
 
     onLocationChange: function(browser, webProgress, request, location, flags) {


### PR DESCRIPTION
This fixes #1122 and #1072, and more generally any case when navigation occurs but no http request is made. Further discussion on this change can be found from https://github.com/gorhill/uBlock/pull/1084#issuecomment-86720922
