### PR TITLE
Fix for #1205

### DIFF
--- a/src/js/pagestore.js
+++ b/src/js/pagestore.js
@@ -637,12 +637,18 @@ PageStore.prototype.toggleNetFilteringSwitch = function(url, scope, state) {
 /******************************************************************************/
 
 PageStore.prototype.filterRequest = function(context) {
-
-    if ( this.getNetFilteringSwitch() === false ) {
-        if ( collapsibleRequestTypes.indexOf(context.requestType) !== -1 ) {
-            this.netFilteringCache.add(context, '');
+    if (context !== this) {
+        // filterRequest coming through for a different URL, don't check the filtering switch for this pageStore, but rather for the context URL.
+        if (µb.getNetFilteringSwitch(context.requestURL) === false) {
+            return '';
         }
-        return '';
+    } else {
+        if ( this.getNetFilteringSwitch() === false ) {
+            if ( collapsibleRequestTypes.indexOf(context.requestType) !== -1 ) {
+                this.netFilteringCache.add(context, '');
+            }
+            return '';
+        }
     }
 
     var entry = this.netFilteringCache.lookup(context);

--- a/src/js/pagestore.js
+++ b/src/js/pagestore.js
@@ -693,8 +693,12 @@ var collapsibleRequestTypes = 'image sub_frame object';
 /******************************************************************************/
 
 PageStore.prototype.filterRequestNoCache = function(context) {
-
-    if ( this.getNetFilteringSwitch() === false ) {
+    if (context !== this) {
+        // filterRequest coming through for a different URL, don't check the filtering switch for this pageStore, but rather for the context URL.
+        if (µb.getNetFilteringSwitch(context.requestURL) === false) {
+            return '';
+        }
+    } else if (this.getNetFilteringSwitch() === false) {
         return '';
     }
 


### PR DESCRIPTION
This fixes #1205. In PageStore.filterRequest, it took care to use `context` for all filtering checks, _except_ the master `getNetFilteringSwitch`. I've fixed that to be consistent. See also traffic.js line 318.

@chrisaljoudi: Thank you for giving me write permissions to the project, but as this is global code, I'd appreciate it if you could give a second opinion on this fix before I merge it.
