### PR TITLE
Add a "Block Element" context menu command to the Firefox Network tab

### DIFF
--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -1944,10 +1944,10 @@ vAPI.contextMenu.displayMenuItem = function({target}) {
 
 /******************************************************************************/
 
-vAPI.contextMenu.createContextMenuItem = function(doc) {
+vAPI.contextMenu.createContextMenuItem = function(doc, labelOverride) {
     var menuitem = doc.createElement('menuitem');
     menuitem.setAttribute('id', this.menuItemId);
-    menuitem.setAttribute('label', this.menuLabel);
+    menuitem.setAttribute('label', labelOverride || this.menuLabel);
     menuitem.setAttribute('image', vAPI.getURL('img/browsericons/icon16.svg'));
     menuitem.setAttribute('class', 'menuitem-iconic');
     return menuitem;
@@ -2038,7 +2038,7 @@ vAPI.contextMenu.registerForNetMonitor = function(eventName, toolbox, panel) {
     var insertBeforeMenuItem = doc.getElementById("request-menu-context-separator");
     
     if (menuPopup && insertBeforeMenuItem) {
-        var menuitem = vAPI.contextMenu.createContextMenuItem(doc);
+        var menuitem = vAPI.contextMenu.createContextMenuItem(doc, vAPI.i18n('netMonitorContextMenuEntry'));
         menuitem.addEventListener('command', function() {
             var selectedRequest = panel.panelWin.NetMonitorView.RequestsMenu.selectedAttachment;
             if (selectedRequest) {

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -2019,7 +2019,7 @@ vAPI.contextMenu.registerForWebInspector = function(eventName, toolbox, panel) {
                 selectedNodeFront = selectedNodeFront.parentNode();
             }
             if (selectedNodeFront) {
-                selectedNodeFront.getUniqueSelector().then(selector => µBlock.elementPickerExec(vAPI.tabs.getTabId(panel.browser), selector));
+                selectedNodeFront.getUniqueSelector().then(selector => µBlock.elementPickerExec(vAPI.tabs.getTabId(panel.browser), { type: 'element', value: selector}));
 
                 // Turn off 3D view, if it's turned on.
                 if (tiltButton && tiltButton.checked) {
@@ -2029,6 +2029,24 @@ vAPI.contextMenu.registerForWebInspector = function(eventName, toolbox, panel) {
         });
 
         menuPopup.insertBefore(menuitem, deleteMenuItem);
+    }
+}
+
+vAPI.contextMenu.registerForNetMonitor = function(eventName, toolbox, panel) {
+    var doc = panel.panelWin.document;
+    var menuPopup = doc.getElementById("network-request-popup");
+    var insertBeforeMenuItem = doc.getElementById("request-menu-context-separator");
+    
+    if (menuPopup && insertBeforeMenuItem) {
+        var menuitem = vAPI.contextMenu.createContextMenuItem(doc);
+        menuitem.addEventListener('command', function() {
+            var selectedRequest = panel.panelWin.NetMonitorView.RequestsMenu.selectedAttachment;
+            if (selectedRequest) {
+                µBlock.elementPickerExec(vAPI.tabs.getTabId(toolbox.target.tab), { type: 'url', value: selectedRequest.url });
+            }
+        });
+
+        menuPopup.insertBefore(menuitem, insertBeforeMenuItem);
     }
 }
 
@@ -2086,6 +2104,7 @@ vAPI.contextMenu.create = function(details, callback) {
 
         if (this.gDevTools) {
             this.gDevTools.on("inspector-ready", this.registerForWebInspector);
+            this.gDevTools.on("netmonitor-ready", this.registerForNetMonitor);
         }
     }
 
@@ -2103,6 +2122,7 @@ vAPI.contextMenu.remove = function() {
 
     if (!vAPI.fennec && this.gDevTools) {
         this.gDevTools.off("inspector-ready", this.registerForWebInspector);
+        this.gDevTools.off("netmonitor-ready", this.registerForNetMonitor);
     }
 
     this.menuItemId = null;

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -147,6 +147,10 @@
     "message":"Block element",
     "description":"English: Block element"
   },
+  "netMonitorContextMenuEntry":{
+    "message":"Block resource",
+    "description":"English: Block resource"
+  },
   "settingsCollapseBlockedPrompt":{
     "message":"Hide placeholders of blocked elements",
     "description":"English: Hide placeholders of blocked elements"

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -138,7 +138,7 @@ return {
     contextMenuClientX: -1,
     contextMenuClientY: -1,
 
-    epickerTargetElementSelector: null,
+    epickerTarget: null,
     epickerEprom: null,
 
     // so that I don't have to care for last comma

--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -558,7 +558,7 @@ var onMessage = function(request, sender, callback) {
 
                 callback({
                     frameContent: this.responseText.replace(reStrings, replacer),
-                    targetElementSelector: µb.epickerTargetElementSelector,
+                    target: µb.epickerTarget,
                     clientX: µb.contextMenuClientX,
                     clientY: µb.contextMenuClientY,
                     eprom: µb.epickerEprom

--- a/src/js/ublock.js
+++ b/src/js/ublock.js
@@ -276,8 +276,8 @@ var matchWhitelistDirective = function(url, hostname, directive) {
 
 /******************************************************************************/
 
-µBlock.elementPickerExec = function(tabId, targetElementSelector) {
-    this.epickerTargetElementSelector = targetElementSelector;
+µBlock.elementPickerExec = function(tabId, target) {
+    this.epickerTarget = target;
     vAPI.tabs.injectScript(tabId, { file: 'js/element-picker.js' });
 };
 

--- a/tools/make-firefox-meta.py
+++ b/tools/make-firefox-meta.py
@@ -24,7 +24,7 @@ source_locale_dir = pj(build_dir, '_locales')
 target_locale_dir = pj(build_dir, 'locale')
 language_codes = []
 descriptions = OrderedDict({})
-title_case_strings = ['pickerContextMenuEntry']
+title_case_strings = ['pickerContextMenuEntry', 'netMonitorContextMenuEntry']
 
 for alpha2 in sorted(os.listdir(source_locale_dir)):
     locale_path = pj(source_locale_dir, alpha2, 'messages.json')


### PR DESCRIPTION
What do you think, would this make a good addition? In my view it complements the Block Element command added to the Inspector tab with #1211 well, as when I want to create a new static filter, I usually end up copying and pasting URLs from here anyway.

![block element from network tab](https://cloud.githubusercontent.com/assets/531706/7338769/45f753bc-ec4e-11e4-8fdf-ba46c2388837.png)
