### PR TITLE
this fixes overlooked code change in 1d3205ea817ccb8a2f03bbaecc9daf19…

### DIFF
--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -1209,7 +1209,7 @@ var httpObserver = {
             // Carry data for behind-the-scene redirects
             channel.setProperty(
                 this.REQDATAKEY,
-                [lastRequest.type, vAPI.noTabId, null, 0, -1]
+                [0, -1, null, vAPI.noTabId, lastRequest.type]
             );
             return;
         }


### PR DESCRIPTION
Looks like a bit of code was overlooked following the changes in 1d3205ea817ccb8a2f03bbaecc9daf19440e300b.

The data in the `this.REQDATAKEY` property bag is not properly ordered for behind-the-scene requests. `httpObserver.asyncOnChannelRedirect` (and further `httpObserver.observer` notifications for same requests) expects the data to be ordered as follow: `frameId`, `parentFrameId`, `sourceTabId`, `tabId`, `type`.
