### PR TITLE
Add vivaldi-scheme as a default in Whitelist

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -76,7 +76,8 @@ return {
         'chrome-extension-scheme',
         'chrome-scheme',
         'loopconversation.about-scheme',
-        'opera-scheme'
+        'opera-scheme',
+        'vivaldi-scheme'
     ].join('\n').trim(),
     
     userFiltersPath: "assets/user/filters.txt",


### PR DESCRIPTION
Vivaldi is another browser based on Blink that supports uBlock. Adding its scheme in the default whitelisting would prevent any issue with it.
