### PR TITLE
Ensure that `url` is cast to a string

### DIFF
--- a/platform/safari/vapi-client.js
+++ b/platform/safari/vapi-client.js
@@ -248,8 +248,8 @@
 var block = function(u, t) {" +
 (legacyMode ?
 "var e = document.createEvent('CustomEvent');\
-e.initCustomEvent('" + vAPI.sessionId + "', false, false, {url: u, type: t});"
-: "var e = new CustomEvent('" + vAPI.sessionId + "', {bubbles: false, detail: {url: u, type: t}});"
+e.initCustomEvent('" + vAPI.sessionId + "', false, false, {url: String(u), type: t});"
+: "var e = new CustomEvent('" + vAPI.sessionId + "', {bubbles: false, detail: {url: String(u), type: t}});"
 ) +
 "document.documentElement.setAttribute('data-ublock-blocked', '');\
 document.dispatchEvent(e);\


### PR DESCRIPTION
If the `url` property of `detail` isn't a string, `detail` can fail to be set. Casting it to a string before synthesizing the event fixes problems like that reported in #1542.