### PR TITLE
Check for vApi property on window to avoid error in Chrome

### DIFF
--- a/src/js/contentscript-end.js
+++ b/src/js/contentscript-end.js
@@ -37,7 +37,7 @@ if ( document instanceof HTMLDocument === false ) {
     return false;
 }
 
-if ( !vAPI ) {
+if ( !window.vAPI ) {
     //console.debug('contentscript-end.js > vAPI not found');
     return;
 }


### PR DESCRIPTION
Chrome display an error when vAPI is not defined instead of just returning.
Checking `window.vApi` instead of just `vAPI` prevents this error.